### PR TITLE
Visual studio project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .build/
 GarageSaveLoadBugModule.dll
-
+**/x86
+**/x64
+**/Debug
+**/Release
+*.user
+*.vs

--- a/GarageSaveLoadBugModule.cpp
+++ b/GarageSaveLoadBugModule.cpp
@@ -28,7 +28,7 @@ EXPORT void mod_init() {
 }
 
 
-__cdecl void* AlignedAlloc(std::size_t allocSize) {
+void* __cdecl AlignedAlloc(std::size_t allocSize) {
 	constexpr std::uintptr_t OriginalAllocAddress = 0x004C21F0;
 	auto allocFunction = reinterpret_cast<decltype(&AlignedAlloc)>(OriginalAllocAddress);
 

--- a/GarageSaveLoadBugModule.sln
+++ b/GarageSaveLoadBugModule.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GarageSaveLoadBugModule", "GarageSaveLoadBugModule.vcxproj", "{F3E69A2E-1D0A-404C-B425-BB7A37A38D22}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "op2extStatic", "op2ext\srcStatic\op2extStatic.vcxproj", "{4F82DF84-DE4A-4AE0-9E05-FC5408AE23BA}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "op2extDLL", "op2ext\srcDLL\op2extDLL.vcxproj", "{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F3E69A2E-1D0A-404C-B425-BB7A37A38D22}.Debug|x86.ActiveCfg = Debug|Win32
+		{F3E69A2E-1D0A-404C-B425-BB7A37A38D22}.Debug|x86.Build.0 = Debug|Win32
+		{F3E69A2E-1D0A-404C-B425-BB7A37A38D22}.Release|x86.ActiveCfg = Release|Win32
+		{F3E69A2E-1D0A-404C-B425-BB7A37A38D22}.Release|x86.Build.0 = Release|Win32
+		{4F82DF84-DE4A-4AE0-9E05-FC5408AE23BA}.Debug|x86.ActiveCfg = Debug|Win32
+		{4F82DF84-DE4A-4AE0-9E05-FC5408AE23BA}.Debug|x86.Build.0 = Debug|Win32
+		{4F82DF84-DE4A-4AE0-9E05-FC5408AE23BA}.Release|x86.ActiveCfg = Release|Win32
+		{4F82DF84-DE4A-4AE0-9E05-FC5408AE23BA}.Release|x86.Build.0 = Release|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Debug|x86.ActiveCfg = Debug|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Debug|x86.Build.0 = Debug|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Release|x86.ActiveCfg = Release|Win32
+		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D48100F5-9524-4526-B5D4-94CD85F70B68}
+	EndGlobalSection
+EndGlobal

--- a/GarageSaveLoadBugModule.vcxproj
+++ b/GarageSaveLoadBugModule.vcxproj
@@ -43,10 +43,10 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <TargetName>op2script</TargetName>
+    <TargetName>op2mod</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>op2script</TargetName>
+    <TargetName>op2mod</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/GarageSaveLoadBugModule.vcxproj
+++ b/GarageSaveLoadBugModule.vcxproj
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{F3E69A2E-1D0A-404C-B425-BB7A37A38D22}</ProjectGuid>
+    <RootNamespace>GarageSaveLoadBugModule</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>op2script</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>op2script</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>./op2ext/srcDLL;./op2ext/srcStatic%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <PostBuildEvent>
+      <Command>if defined Outpost2Path (xcopy /y /d "$(TargetPath)" "$(Outpost2Path)\GarageSaveLoadBug\") else (echo Outpost2Path environment variable not defined. Skipping Post Build Copy.)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy DLL into Outpost 2 directory</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>./op2ext/srcDLL;./op2ext/srcStatic%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <PostBuildEvent>
+      <Command>if defined Outpost2Path (xcopy /y /d "$(TargetPath)" "$(Outpost2Path)\GarageSaveLoadBug\") else (echo Outpost2Path environment variable not defined. Skipping Post Build Copy.)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy DLL into Outpost 2 directory</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="GarageSaveLoadBugModule.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="op2ext\srcDLL\op2extDLL.vcxproj">
+      <Project>{6de3610c-c9ee-4fd3-bbd7-66382c16fde9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="op2ext\srcStatic\op2extStatic.vcxproj">
+      <Project>{4f82df84-de4a-4ae0-9e05-fc5408ae23ba}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/GarageSaveLoadBugModule.vcxproj.filters
+++ b/GarageSaveLoadBugModule.vcxproj.filters
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="GarageSaveLoadBugModule.cpp" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This seems to be abusing the private interfaces of op2ext. I suppose that is okay for a test module, but will make it more brittle moving forward. 

Also, it might be worth stating in the readme not to use it as an example when creating new modules?

Outpost 2 will properly load this as a console module. I didn't actually test its specific design yet.